### PR TITLE
Add bug reports from WebKit and Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Temporal.TimeZone.from('Europe/Zagreb');
 - [CLDR-9718: Rename from Asia/Calcutta to Asia/Kolkata in Zone - Tzid mapping and windows mapping](https://unicode-org.atlassian.net/browse/CLDR-9718)
 - [Incorrect canonical time zone name for Asia/Kolkata · Issue #1076 · tc39/proposal-temporal](https://github.com/tc39/proposal-temporal/issues/1076)
 - [[tz] Kyiv not Kiev](https://mm.icann.org/pipermail/tz/2021-January/029695.html) (from [IANA TZDB mailing list](https://mm.icann.org/pipermail/tz/)).
+- [WebKit 218542: Incorrect timezone returned for Buenos Aires](https://bugs.webkit.org/show_bug.cgi?id=218542)
+- [Firefox 1796393: Javascript returns problematic timezone, breaking sites](https://bugzilla.mozilla.org/show_bug.cgi?id=1796393)
+- [Firefox 1825512: Europe/Kyiv is not a valid IANA timezone identifier](https://bugzilla.mozilla.org/show_bug.cgi?id=1825512)
 - It's easy to find dozens more.
 
 ### Can't depend on static data behaving the same over time


### PR DESCRIPTION
The two Firefox bugs seem to be the only ones which actually affect Firefox users. There's also [bug 1740721](https://bugzilla.mozilla.org/show_bug.cgi?id=1740721), but that one seems more like a bug report filed after performing differential testing between browsers. 

[Bug 1797223](https://bugzilla.mozilla.org/show_bug.cgi?id=1797223) is also kind of interesting for cross-browser compatibility: A website was using `"CST"` as a time zone identifier. `"CST"` isn't a valid IANA/CLDR time zone identifier, so it should be rejected by implementations, but ICU actually supports `"CST"` for backward compatibility reasons. So when implementations directly call ICU without any additional pre- or post-processing to handle [ICU zones](https://github.com/unicode-org/icu/blob/main/icu4c/source/tools/tzcode/icuzones), `"CST"` is incorrectly accepted. 

Not sure if it's worth to document [bug 1679532](https://bugzilla.mozilla.org/show_bug.cgi?id=1679532) or [bug 1802942](https://bugzilla.mozilla.org/show_bug.cgi?id=1802942), which are both examples where the _Windows time zone identifier_ to _IANA/CLDR time zone identifier_ mapping wasn't working correctly. (The mapping is defined in CLDR at <https://github.com/unicode-org/cldr/blob/main/common/supplemental/windowsZones.xml>.) Bug 1802942 is probably still an issue, at least [the comments in the Windows Daylight Saving Time & Time Zone blog](https://techcommunity.microsoft.com/t5/daylight-saving-time-time-zone/mexico-2023-time-zone-updates-now-available/ba-p/3749684) indicate that some Windows users in Mexico still can't select their correct time zone, but I can't verify this right now. 